### PR TITLE
Alias .welcome + .welcomefreq

### DIFF
--- a/CANscope/CZUL/CZUL Aliases.txt
+++ b/CANscope/CZUL/CZUL Aliases.txt
@@ -10,8 +10,8 @@
 .welcome Welcome to Montréal, taxi via $1, $2, $3, $4, See ya!
 ..welcome Bienvenue à Montréal, circulez $1, $2, $3, $4, À la prochaine!
 
-.welcomefreq Welcome to Montréal, Contact $radioname(UA) on $freq(UA), See ya!
-..welcomefreq Bienvenue à Montréal, Contactez $radioname(UA) sur $freq(UA), À la prochaine!
+.welcomefreq Welcome to Montréal, taxi via $1, cross runway 28, $2, Contact $radioname(UA) on $freq(UA), See ya!
+..welcomefreq Bienvenue à Montréal, circulez $1, traversez piste 28, $2, Contactez $radioname(UA) sur $freq(UA), À la prochaine!
 
 .to Call me when airborne, wind $wind , Cleared for take-off runway $deprwy(CYUL)
 ..to Appelez-moi à l’envol, vent $wind, autorisé à décoller piste $deprwy(CYUL)

--- a/CANscope/CZUL/CZUL Aliases.txt
+++ b/CANscope/CZUL/CZUL Aliases.txt
@@ -7,8 +7,11 @@
 .twrfreq Contact $radioname(UL) on $freq(UL) ; See ya!
 ..twrfreq Contactez $radioname(UL) sur $freq(UL) Bon vol!
 
-.welcome Welcome to Montréal–Pierre Elliott Trudeau International Airport, taxi via $1, cross runway 28, $2, hold short of apron, contact $radioname(UA) on $freq(UA), good day
-..welcome Bienvenue à l’aéroport international Montréal Pierre-Elliott Trudeau, circulez $1, traversez piste 28, $2, restez à l’écart du tablier, contactez $radioname(UA) sur $freq(UA), bonne journée!
+.welcome Welcome to Montréal, taxi via $1, $2, $3, $4, See ya!
+..welcome Bienvenue à Montréal, circulez $1, $2, $3, $4, À la prochaine!
+
+.welcomefreq Welcome to Montréal, Contact $radioname(UA) on $freq(UA), See ya!
+..welcomefreq Bienvenue à Montréal, Contactez $radioname(UA) sur $freq(UA), À la prochaine!
 
 .to Call me when airborne, wind $wind , Cleared for take-off runway $deprwy(CYUL)
 ..to Appelez-moi à l’envol, vent $wind, autorisé à décoller piste $deprwy(CYUL)

--- a/CANscope/CZUL/CZUL Aliases.txt
+++ b/CANscope/CZUL/CZUL Aliases.txt
@@ -10,8 +10,8 @@
 .welcome Welcome to Montréal, taxi via $1, $2, $3, $4, See ya!
 ..welcome Bienvenue à Montréal, circulez $1, $2, $3, $4, À la prochaine!
 
-.welcomefreq Welcome to Montréal, taxi via $1, cross runway 28, $2, Contact $radioname(UA) on $freq(UA), See ya!
-..welcomefreq Bienvenue à Montréal, circulez $1, traversez piste 28, $2, Contactez $radioname(UA) sur $freq(UA), À la prochaine!
+.welcomefreq Welcome to Montréal, Contact $radioname(UA) on $freq(UA), See ya!
+..welcomefreq Bienvenue à Montréal, Contactez $radioname(UA) sur $freq(UA), À la prochaine!
 
 .to Call me when airborne, wind $wind , Cleared for take-off runway $deprwy(CYUL)
 ..to Appelez-moi à l’envol, vent $wind, autorisé à décoller piste $deprwy(CYUL)


### PR DESCRIPTION
"restez à l’écart du tablier" should not be in the aliases because by default we don't control it in CZUL, could be in another alias but default welcome should say "taxi apron at your discretion";
"Welcome to Montréal–Pierre Elliott Trudeau International Airport" is unrealistic and "Welcome to Montréal" seems nicer and is more realistic;